### PR TITLE
Added new areas to block Outlook ads

### DIFF
--- a/outlook-noad.js
+++ b/outlook-noad.js
@@ -7,14 +7,16 @@ function applycss(css) {
 }
 
 applycss(`
-._2qPmszDwBfYpF7PO9Mn3KN, 
-._3a6SuYqdwIspGohT1zu16B, 
+._2qPmszDwBfYpF7PO9Mn3KN,
+._3a6SuYqdwIspGohT1zu16B,
 ._1_ag99JsBHxI6S4FP5ayPv,
 ._3_hHr3kfEhbNYRFM5YJxH9,
 ._2F6rWwLisyawGGg32JOcop,
 ._23fxOotSm5HPNB1U_ZVw4i,
 ._1fti_QgAzqGWPGlqh_FSvI,
-._1fti_QgAzqGWPGlqh_FSvI
+._1fti_QgAzqGWPGlqh_FSvI,
+._1elFdDtE02urszo_h9-MJw,
+._151cu27-mizfa2_45gn3Zp
 {
     display:none !important;
 }

--- a/outlook-noad.js
+++ b/outlook-noad.js
@@ -16,7 +16,8 @@ applycss(`
 ._1fti_QgAzqGWPGlqh_FSvI,
 ._1fti_QgAzqGWPGlqh_FSvI,
 ._1elFdDtE02urszo_h9-MJw,
-._151cu27-mizfa2_45gn3Zp
+._151cu27-mizfa2_45gn3Zp,
+._2_TS1mjVqZoXWVRD0GM3re
 {
     display:none !important;
 }


### PR DESCRIPTION
Outlook released another box on the left panel with ads and an inline ad that looks like a new mail. The latter is only seen if you choose the recommended panel how your ads should be displayed. Either way I included both versions.